### PR TITLE
QR BMesh, UI enhancements, and various refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # Changelog
+## [1.2.0]
+
+### Added
+- Boolean solver choice (Exact / Fast) for design boolean operations in the UI
+- Diagnostic error reporting for SVG-to-mesh pipeline failures (logo placer node group, design input node, assignment errors)
+
+### Fixed
+- NFC cavity choice modifier sync error on file reload ("Could not sync 1 modifier values: NFC_CAVITY_CHOICE")
+- QR mode toggle not resetting the design flag when switching between QR and SVG modes
+- ROUNDED QR module style rendering incorrectly
+- SVG import now extrudes each path individually before joining, producing correct geometry for multi-path designs
+- Boolean self-union applied to imported SVG meshes to resolve overlapping shell issues
+- QR code mesh Z-origin now centred for proper card placement
+
+### Changed
+- QR code generation rewritten to use direct BMesh construction instead of SVG intermediary
+- SVG import pipeline dramatically faster — per-path extrusion and manifold-making now completes most tested designs in under a second
+- Modifier-to-property sync rewritten with dictionary-based enum conversion for robustness
+
 ## [1.1.8]
 ### Optimized
 - Reduced .blend file size by using Quick Asset Saver Add-on for saving the card to a clean small asset file. 
@@ -58,7 +77,7 @@
 
 ## Version History
 
-- **[1.2.0]** - Text overlay and custom font support
+- **[1.2.0]** - Boolean solver UI, QR BMesh rewrite, dead code cleanup, bug fixes
 - **[1.1.8]** - .blend file size optimization
 - **[1.1.7]** - Viewport camera controls and automation
 - **[1.1.6]** - Core functionality and features

--- a/nfcCardGen/blender_manifest.toml
+++ b/nfcCardGen/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "nfc_card_keychain_generator"
-version = "1.1.8"
+version = "1.2.0"
 name = "NFC Card and Keychain Generator"
 tagline = "Generate customizable 3D-printable cards, tags, and keychains"
 maintainer = "Clonephaze <jack@clonecore.net>"
@@ -10,20 +10,6 @@ license = ['SPDX:GPL-3.0-or-later']
 website = "https://github.com/Clonephaze/nfc-keychain-generator-blender-addon"
 copyright = ["2025 Clonephaze"]
 tags = ["Modeling", "Object"]
-description = """
-A comprehensive add-on for generating customizable 3D-printable cards, tags, and keychains.
-
-Features:
-- Base shapes: cards, circles, with optional keychain loops
-- Configurable dimensions with rounded corners
-- NFC slots and magnet hole cutouts with taper control
-- Edge beveling with adjustable segments
-- Logo/QR code placement (automated and manual workflows)
-- SVG import pipeline for custom graphics
-- Built-in QR code generation
-
-Uses Geometry Nodes and modifiers for maximum flexibility and performance.
-"""
 
 wheels = ["./wheels/segno-1.6.6-py3-none-any.whl"]
 

--- a/nfcCardGen/operators.py
+++ b/nfcCardGen/operators.py
@@ -188,21 +188,46 @@ class OBJECT_OT_scene_setup(Operator):
 
     def _sync_modifier_values_to_props(self, context, card_obj) -> None:
         """Fetch modifier values and update scene properties"""
+        # Menu sockets store integers; map them back to EnumProperty identifiers
+        _ENUM_INT_TO_STR = {
+            "SHAPE_CHOICE": {0: "RECTANGLE", 1: "CIRCLE"},
+            "MAG_SHAPE": {0: "CIRCLE", 1: "HEXAGON"},
+            "NFC_CAVITY_CHOICE": {0: "RECTANGLE", 1: "CIRCLE", 2: "DOUBLE_CIRCLE"},
+        }
+        # Where logical_name.lower() doesn't match the actual property name
+        _PROP_NAME_OVERRIDES = {
+            "SHAPE_CHOICE": "shape_preset",
+            "CORNER_RADII": "corner_radius",
+        }
+
+        failed = []
         for logical_name, (modifier_name, socket_name) in MOD_OPT_MAPPING.items():
             try:
                 value = get_modifier_value(card_obj, modifier_name, socket_name)
                 if value is not None:
-                    # Special handling for enum properties that are stored as integers in geometry nodes
-                    if logical_name == "MAG_SHAPE":
-                        # Convert integer value to string enum value
-                        # 0 = "CIRCLE", 1 = "HEXAGON"
-                        value = "CIRCLE" if value == 0 else "HEXAGON"
+                    # Convert integer menu-socket values to string enum identifiers
+                    enum_map = _ENUM_INT_TO_STR.get(logical_name)
+                    if enum_map is not None:
+                        value = enum_map.get(value, next(iter(enum_map.values())))
 
-                    setattr(context.scene.nfc_card_props, logical_name.lower(), value)
-            except Exception as e:
-                print(
-                    f"Warning: Could not fetch initial value for {logical_name}: {str(e)}"
-                )
+                    prop_name = _PROP_NAME_OVERRIDES.get(
+                        logical_name, logical_name.lower()
+                    )
+                    setattr(context.scene.nfc_card_props, prop_name, value)
+            except Exception:
+                failed.append(logical_name)
+
+        if failed:
+            self.report(
+                {"WARNING"},
+                f"Could not sync {len(failed)} modifier values: {', '.join(failed)}",
+            )
+
+        # Sync the design boolean solver (node-level property, not a socket)
+        from .utils import get_design_boolean_solver
+        solver = get_design_boolean_solver()
+        if solver is not None:
+            context.scene.nfc_card_props.design_boolean_solver = solver
 
     def _setup_modifier_drivers(self, card_obj) -> None:
         """Set up drivers between modifiers based on DRIVER_MAPPINGS"""
@@ -246,28 +271,16 @@ class OBJECT_OT_nfc_toggle_boolean_option(Operator):
         """Toggle the boolean option via the modifier socket."""
         props = context.scene.nfc_card_props
 
-        # Get current value and toggle it
+        # Setting the property triggers its update callback, which handles
+        # modifier updates and geometry refresh automatically.
         if self.option_type == "MAGNET_CHOICE":
-            current_value = props.magnet_choice
-            props.magnet_choice = not current_value
-            new_value = props.magnet_choice
+            props.magnet_choice = not props.magnet_choice
         elif self.option_type == "INSET_CHOICE":
-            current_value = props.inset_choice
-            props.inset_choice = not current_value
-            new_value = props.inset_choice
+            props.inset_choice = not props.inset_choice
         elif self.option_type == "KEYCHAIN_CHOICE":
-            current_value = props.keychain_choice
-            props.keychain_choice = not current_value
-            new_value = props.keychain_choice
+            props.keychain_choice = not props.keychain_choice
 
-        print(f"Toggling {self.option_type}: {current_value} -> {new_value}")
-
-        if update_modifier_option(self.option_type, new_value, self.report):
-            force_update_ui_and_geometry(context, self.option_type.lower())
-
-            return {"FINISHED"}
-        else:
-            return {"CANCELLED"}
+        return {"FINISHED"}
 
 
 class OBJECT_OT_nfc_set_shape_preset(Operator):
@@ -621,18 +634,26 @@ class OBJECT_OT_nfc_export_stl(Operator, ExportHelper):
             return {"CANCELLED"}
 
 
-class OBJECT_OT_nfc_load_font_design1(Operator, ImportHelper):
-    """Load a custom font for Design 1 text"""
+class OBJECT_OT_nfc_load_font(Operator, ImportHelper):
+    """Load a custom font for a design's text"""
 
-    bl_idname = "object.nfc_load_font_design1"
+    bl_idname = "object.nfc_load_font"
     bl_label = "Load Font"
-    bl_description = "Load a custom TrueType or OpenType font for Design 1 text"
+    bl_description = "Load a custom TrueType or OpenType font"
     bl_options = {"REGISTER", "UNDO"}
 
     filter_glob: StringProperty(
         default="*.ttf;*.otf;*.TTF;*.OTF",
         options={"HIDDEN"},
         maxlen=255,
+    )
+
+    design_num: bpy.props.IntProperty(
+        name="Design Number",
+        description="Which design slot to load font for (1 or 2)",
+        default=1,
+        min=1,
+        max=2,
     )
 
     @classmethod
@@ -643,93 +664,14 @@ class OBJECT_OT_nfc_load_font_design1(Operator, ImportHelper):
         return OBJECT_NAME in bpy.data.objects
 
     def execute(self, context) -> Set[str]:
-        """Load the font and apply it to the Design 1 text node."""
+        """Load the font and apply it to the specified design's text node."""
         try:
             # Store the font path in properties
-            context.scene.nfc_card_props.font_path_1 = self.filepath
-
-            # Get the card object
-            card_obj = bpy.data.objects.get(OBJECT_NAME)
-            if not card_obj:
-                self.report({"ERROR"}, f"Card object '{OBJECT_NAME}' not found")
-                return {"CANCELLED"}
-
-            # Find the Logo Placer modifier
-            logo_placer_mod = card_obj.modifiers.get("Logo Placer")
-            if not logo_placer_mod or not hasattr(logo_placer_mod, "node_group"):
-                self.report({"ERROR"}, "Logo Placer modifier not found")
-                return {"CANCELLED"}
-
-            # Navigate to the Design Placement.001 node group within Logo Placer
-            logo_placer_tree = logo_placer_mod.node_group
-            design_placement_node = None
-            for node in logo_placer_tree.nodes:
-                if node.type == 'GROUP' and node.name == "Design 1 Input Values":
-                    design_placement_node = node
-                    break
-
-            if not design_placement_node or not design_placement_node.node_tree:
-                self.report({"ERROR"}, "Design 1 Input Values node group not found")
-                return {"CANCELLED"}
-
-            # Find the String to Curves node
-            design_placement_tree = design_placement_node.node_tree
-            string_to_curves = None
-            for node in design_placement_tree.nodes:
-                if node.type == 'STRING_TO_CURVES':
-                    string_to_curves = node
-                    break
-
-            if not string_to_curves:
-                self.report({"ERROR"}, "String to Curves node not found in Design 1")
-                return {"CANCELLED"}
-
-            # Load the font as a VectorFont data block
-            if self.filepath not in bpy.data.fonts:
-                font = bpy.data.fonts.load(self.filepath)
-            else:
-                font = bpy.data.fonts[self.filepath]
-
-            # Apply the font to the String to Curves node (it's a node property, not a socket)
-            string_to_curves.font = font
-
-            self.report(
-                {"INFO"},
-                f"Font loaded for Design 1: {os.path.basename(self.filepath)}",
+            setattr(
+                context.scene.nfc_card_props,
+                f"font_path_{self.design_num}",
+                self.filepath,
             )
-            return {"FINISHED"}
-
-        except Exception as e:
-            self.report({"ERROR"}, f"Failed to load font: {str(e)}")
-            return {"CANCELLED"}
-
-
-class OBJECT_OT_nfc_load_font_design2(Operator, ImportHelper):
-    """Load a custom font for Design 2 text"""
-
-    bl_idname = "object.nfc_load_font_design2"
-    bl_label = "Load Font"
-    bl_description = "Load a custom TrueType or OpenType font for Design 2 text"
-    bl_options = {"REGISTER", "UNDO"}
-
-    filter_glob: StringProperty(
-        default="*.ttf;*.otf;*.TTF;*.OTF",
-        options={"HIDDEN"},
-        maxlen=255,
-    )
-
-    @classmethod
-    def poll(cls, context) -> bool:
-        """Only allow if scene is set up and Card object exists."""
-        if not context.scene.nfc_card_props.scene_setup:
-            return False
-        return OBJECT_NAME in bpy.data.objects
-
-    def execute(self, context) -> Set[str]:
-        """Load the font and apply it to the Design 2 text node."""
-        try:
-            # Store the font path in properties
-            context.scene.nfc_card_props.font_path_2 = self.filepath
 
             # Get the card object
             card_obj = bpy.data.objects.get(OBJECT_NAME)
@@ -743,16 +685,17 @@ class OBJECT_OT_nfc_load_font_design2(Operator, ImportHelper):
                 self.report({"ERROR"}, "Logo Placer modifier not found")
                 return {"CANCELLED"}
 
-            # Navigate to the Design Placement.001 node group within Logo Placer
+            # Navigate to the design's input node group within Logo Placer
+            node_name = f"Design {self.design_num} Input Values"
             logo_placer_tree = logo_placer_mod.node_group
             design_placement_node = None
             for node in logo_placer_tree.nodes:
-                if node.type == 'GROUP' and node.name == "Design 2 Input Values":
+                if node.type == 'GROUP' and node.name == node_name:
                     design_placement_node = node
                     break
 
             if not design_placement_node or not design_placement_node.node_tree:
-                self.report({"ERROR"}, "Design 2 Input Values node group not found")
+                self.report({"ERROR"}, f"{node_name} node group not found")
                 return {"CANCELLED"}
 
             # Find the String to Curves node
@@ -764,7 +707,10 @@ class OBJECT_OT_nfc_load_font_design2(Operator, ImportHelper):
                     break
 
             if not string_to_curves:
-                self.report({"ERROR"}, "String to Curves node not found in Design 2")
+                self.report(
+                    {"ERROR"},
+                    f"String to Curves node not found in Design {self.design_num}",
+                )
                 return {"CANCELLED"}
 
             # Load the font as a VectorFont data block
@@ -773,12 +719,12 @@ class OBJECT_OT_nfc_load_font_design2(Operator, ImportHelper):
             else:
                 font = bpy.data.fonts[self.filepath]
 
-            # Apply the font to the String to Curves node (it's a node property, not a socket)
+            # Apply the font to the String to Curves node
             string_to_curves.font = font
 
             self.report(
                 {"INFO"},
-                f"Font loaded for Design 2: {os.path.basename(self.filepath)}",
+                f"Font loaded for Design {self.design_num}: {os.path.basename(self.filepath)}",
             )
             return {"FINISHED"}
 
@@ -795,8 +741,7 @@ CLASSES = (
     OBJECT_OT_nfc_set_cavity_shape,
     OBJECT_OT_nfc_set_view,
     OBJECT_OT_nfc_export_stl,
-    OBJECT_OT_nfc_load_font_design1,
-    OBJECT_OT_nfc_load_font_design2,
+    OBJECT_OT_nfc_load_font,
 )
 
 

--- a/nfcCardGen/properties.py
+++ b/nfcCardGen/properties.py
@@ -40,242 +40,72 @@ def update_property(self, context, prop_name, logical_name, value):
 
 
 # Property-specific update callbacks that delegate to the generic function
-def update_corner_radii(self, context):
-    """Update callback for corner_radius property."""
-    update_property(self, context, "corner_radius", "CORNER_RADII", self.corner_radius)
-
-
-def update_keychain_choice(self, context):
-    """Update callback for keychain_choice property."""
-    update_property(
-        self, context, "keychain_choice", "KEYCHAIN_CHOICE", self.keychain_choice
-    )
-
-
-def update_initial_height(self, context):
-    """Update callback for initial_height property."""
-    update_property(
-        self, context, "initial_height", "INITIAL_HEIGHT", self.initial_height
-    )
-
-
-def update_magnet_choice(self, context):
-    """Update callback for magnet_choice property."""
-    update_property(self, context, "magnet_choice", "MAGNET_CHOICE", self.magnet_choice)
-
-
-def update_magnet_depth(self, context):
-    """Update callback for magnet_depth property."""
-    update_property(self, context, "magnet_depth", "MAGNET_DEPTH", self.magnet_depth)
-
-
-def update_nfc_cutout(self, context):
-    """Update callback for nfc_choice property."""
-    update_property(self, context, "nfc_choice", "NFC_CHOICE", self.nfc_choice)
-
-
-def update_bevel_amount(self, context):
-    """Update callback for bevel_amount property."""
-    update_property(self, context, "bevel_amount", "BEVEL_AMOUNT", self.bevel_amount)
-
-
-def update_bevel_segment_count(self, context):
-    """Update callback for bevel_segments property."""
-    update_property(
-        self, context, "bevel_segments", "BEVEL_SEGMENTS", self.bevel_segments
-    )
-
-
-def update_mag_shape(self, context):
-    """Update callback for mag_shape property."""
-    update_property(self, context, "mag_shape", "MAG_SHAPE", self.mag_shape)
-
-
-def update_mag_width(self, context):
-    """Update callback for mag_width property."""
-    update_property(self, context, "mag_width", "MAG_WIDTH", self.mag_width)
-
-
-def update_mag_taper(self, context):
-    """Update callback for mag_taper property."""
-    update_property(self, context, "mag_taper", "MAG_TAPER", self.mag_taper)
-
-
-def update_mag_padding(self, context):
-    """Update callback for MAG_EDGE_PAD property."""
-    update_property(self, context, "mag_padding", "MAG_EDGE_PAD", self.mag_padding)
-
-
-def update_inset_choice(self, context):
-    """Update callback for inset_choice property."""
-    update_property(self, context, "inset_choice", "INSET_CHOICE", self.inset_choice)
-
-
-def update_offset_x_1(self, context):
-    """Update callback for offset_x_1 property."""
-    update_property(self, context, "offset_x_1", "OFFSET_X_1", self.offset_x_1)
-
-
-def update_offset_y_1(self, context):
-    """Update callback for offset_y_1 property."""
-    update_property(self, context, "offset_y_1", "OFFSET_Y_1", self.offset_y_1)
-
-
-def update_scale_1(self, context):
-    """Update callback for scale_1 property."""
-    update_property(self, context, "scale_1", "SCALE_1", self.scale_1)
-
-
-def update_offset_x_2(self, context):
-    """Update callback for offset_x_2 property."""
-    update_property(self, context, "offset_x_2", "OFFSET_X_2", self.offset_x_2)
-
-
-def update_offset_y_2(self, context):
-    """Update callback for offset_y_2 property."""
-    update_property(self, context, "offset_y_2", "OFFSET_Y_2", self.offset_y_2)
-
-
-def update_scale_2(self, context):
-    """Update callback for scale_2 property."""
-    update_property(self, context, "scale_2", "SCALE_2", self.scale_2)
-
-
-def update_nfc_cavity_height(self, context):
-    """Update callback for nfc_cavity_height property."""
-    update_property(
-        self, context, "nfc_cavity_height", "NFC_CAVITY_HEIGHT", self.nfc_cavity_height
-    )
-
-
-# Text property update callbacks - Design 1
-def update_design_1_text(self, context):
-    """Update callback for design_1_text property."""
-    update_property(self, context, "design_1_text", "DESIGN_1_TEXT", self.design_1_text)
-
-
-def update_text_1(self, context):
-    """Update callback for text_1 property."""
-    update_property(self, context, "text_1", "TEXT_1", self.text_1)
-
-
-def update_text_size_1(self, context):
-    """Update callback for text_size_1 property."""
-    update_property(self, context, "text_size_1", "TEXT_SIZE_1", self.text_size_1)
-
-
-def update_character_spacing_1(self, context):
-    """Update callback for character_spacing_1 property."""
-    update_property(
-        self, context, "character_spacing_1", "CHARACTER_SPACING_1", self.character_spacing_1
-    )
-
-
-def update_word_spacing_1(self, context):
-    """Update callback for word_spacing_1 property."""
-    update_property(
-        self, context, "word_spacing_1", "WORD_SPACING_1", self.word_spacing_1
-    )
-
-
-def update_line_spacing_1(self, context):
-    """Update callback for line_spacing_1 property."""
-    update_property(
-        self, context, "line_spacing_1", "LINE_SPACING_1", self.line_spacing_1
-    )
-
-
-def update_text_box_width_1(self, context):
-    """Update callback for text_box_width_1 property."""
-    update_property(
-        self, context, "text_box_width_1", "TEXT_BOX_WIDTH_1", self.text_box_width_1
-    )
-
-
-def update_text_box_height_1(self, context):
-    """Update callback for text_box_height_1 property."""
-    update_property(
-        self, context, "text_box_height_1", "TEXT_BOX_HEIGHT_1", self.text_box_height_1
-    )
-
-
-def update_text_x_offset_1(self, context):
-    """Update callback for text_x_offset_1 property."""
-    update_property(
-        self, context, "text_x_offset_1", "TEXT_X_OFFSET_1", self.text_x_offset_1
-    )
-
-
-def update_text_y_offset_1(self, context):
-    """Update callback for text_y_offset_1 property."""
-    update_property(
-        self, context, "text_y_offset_1", "TEXT_Y_OFFSET_1", self.text_y_offset_1
-    )
-
-
-# Text property update callbacks - Design 2
-def update_design_2_text(self, context):
-    """Update callback for design_2_text property."""
-    update_property(self, context, "design_2_text", "DESIGN_2_TEXT", self.design_2_text)
-
-
-def update_text_2(self, context):
-    """Update callback for text_2 property."""
-    update_property(self, context, "text_2", "TEXT_2", self.text_2)
-
-
-def update_text_size_2(self, context):
-    """Update callback for text_size_2 property."""
-    update_property(self, context, "text_size_2", "TEXT_SIZE_2", self.text_size_2)
-
-
-def update_character_spacing_2(self, context):
-    """Update callback for character_spacing_2 property."""
-    update_property(
-        self, context, "character_spacing_2", "CHARACTER_SPACING_2", self.character_spacing_2
-    )
-
-
-def update_word_spacing_2(self, context):
-    """Update callback for word_spacing_2 property."""
-    update_property(
-        self, context, "word_spacing_2", "WORD_SPACING_2", self.word_spacing_2
-    )
-
-
-def update_line_spacing_2(self, context):
-    """Update callback for line_spacing_2 property."""
-    update_property(
-        self, context, "line_spacing_2", "LINE_SPACING_2", self.line_spacing_2
-    )
-
-
-def update_text_box_width_2(self, context):
-    """Update callback for text_box_width_2 property."""
-    update_property(
-        self, context, "text_box_width_2", "TEXT_BOX_WIDTH_2", self.text_box_width_2
-    )
-
-
-def update_text_box_height_2(self, context):
-    """Update callback for text_box_height_2 property."""
-    update_property(
-        self, context, "text_box_height_2", "TEXT_BOX_HEIGHT_2", self.text_box_height_2
-    )
-
-
-def update_text_x_offset_2(self, context):
-    """Update callback for text_x_offset_2 property."""
-    update_property(
-        self, context, "text_x_offset_2", "TEXT_X_OFFSET_2", self.text_x_offset_2
-    )
-
-
-def update_text_y_offset_2(self, context):
-    """Update callback for text_y_offset_2 property."""
-    update_property(
-        self, context, "text_y_offset_2", "TEXT_Y_OFFSET_2", self.text_y_offset_2
-    )
+def _make_updater(prop_attr: str, logical_name: str):
+    """Factory that creates an update callback for a Blender property.
+
+    Args:
+        prop_attr: The attribute name on the PropertyGroup (e.g. "corner_radius")
+        logical_name: The key in MOD_OPT_MAPPING (e.g. "CORNER_RADII")
+    """
+    def _update(self, context):
+        update_property(self, context, prop_attr, logical_name, getattr(self, prop_attr))
+    return _update
+
+
+# Shape & dimension callbacks
+update_corner_radii = _make_updater("corner_radius", "CORNER_RADII")
+update_keychain_choice = _make_updater("keychain_choice", "KEYCHAIN_CHOICE")
+update_initial_height = _make_updater("initial_height", "INITIAL_HEIGHT")
+update_magnet_choice = _make_updater("magnet_choice", "MAGNET_CHOICE")
+update_magnet_depth = _make_updater("magnet_depth", "MAGNET_DEPTH")
+update_nfc_cutout = _make_updater("nfc_choice", "NFC_CHOICE")
+update_bevel_amount = _make_updater("bevel_amount", "BEVEL_AMOUNT")
+update_bevel_segment_count = _make_updater("bevel_segments", "BEVEL_SEGMENTS")
+
+# Magnet callbacks
+update_mag_shape = _make_updater("mag_shape", "MAG_SHAPE")
+update_mag_width = _make_updater("mag_width", "MAG_WIDTH")
+update_mag_taper = _make_updater("mag_taper", "MAG_TAPER")
+update_mag_padding = _make_updater("mag_padding", "MAG_EDGE_PAD")
+
+# Design layout callbacks
+update_inset_choice = _make_updater("inset_choice", "INSET_CHOICE")
+
+def update_design_boolean_solver(self, context):
+    """Update the boolean solver on Logo Placer Mesh Boolean nodes."""
+    from .utils import update_design_boolean_solver as _apply_solver
+    _apply_solver(self.design_boolean_solver)
+update_offset_x_1 = _make_updater("offset_x_1", "OFFSET_X_1")
+update_offset_y_1 = _make_updater("offset_y_1", "OFFSET_Y_1")
+update_scale_1 = _make_updater("scale_1", "SCALE_1")
+update_offset_x_2 = _make_updater("offset_x_2", "OFFSET_X_2")
+update_offset_y_2 = _make_updater("offset_y_2", "OFFSET_Y_2")
+update_scale_2 = _make_updater("scale_2", "SCALE_2")
+update_nfc_cavity_height = _make_updater("nfc_cavity_height", "NFC_CAVITY_HEIGHT")
+
+# Text callbacks – Design 1
+update_design_1_text = _make_updater("design_1_text", "DESIGN_1_TEXT")
+update_text_1 = _make_updater("text_1", "TEXT_1")
+update_text_size_1 = _make_updater("text_size_1", "TEXT_SIZE_1")
+update_character_spacing_1 = _make_updater("character_spacing_1", "CHARACTER_SPACING_1")
+update_word_spacing_1 = _make_updater("word_spacing_1", "WORD_SPACING_1")
+update_line_spacing_1 = _make_updater("line_spacing_1", "LINE_SPACING_1")
+update_text_box_width_1 = _make_updater("text_box_width_1", "TEXT_BOX_WIDTH_1")
+update_text_box_height_1 = _make_updater("text_box_height_1", "TEXT_BOX_HEIGHT_1")
+update_text_x_offset_1 = _make_updater("text_x_offset_1", "TEXT_X_OFFSET_1")
+update_text_y_offset_1 = _make_updater("text_y_offset_1", "TEXT_Y_OFFSET_1")
+
+# Text callbacks – Design 2
+update_design_2_text = _make_updater("design_2_text", "DESIGN_2_TEXT")
+update_text_2 = _make_updater("text_2", "TEXT_2")
+update_text_size_2 = _make_updater("text_size_2", "TEXT_SIZE_2")
+update_character_spacing_2 = _make_updater("character_spacing_2", "CHARACTER_SPACING_2")
+update_word_spacing_2 = _make_updater("word_spacing_2", "WORD_SPACING_2")
+update_line_spacing_2 = _make_updater("line_spacing_2", "LINE_SPACING_2")
+update_text_box_width_2 = _make_updater("text_box_width_2", "TEXT_BOX_WIDTH_2")
+update_text_box_height_2 = _make_updater("text_box_height_2", "TEXT_BOX_HEIGHT_2")
+update_text_x_offset_2 = _make_updater("text_x_offset_2", "TEXT_X_OFFSET_2")
+update_text_y_offset_2 = _make_updater("text_y_offset_2", "TEXT_Y_OFFSET_2")
 
 
 class NFCCardProperties(PropertyGroup):
@@ -285,6 +115,19 @@ class NFCCardProperties(PropertyGroup):
     These properties will be exposed in the UI panel and passed to
     geometry node groups for card generation.
     """
+
+    # ---- Computed height helpers ----
+    def get_card_height(self) -> float:
+        """Card body height before design layer is added."""
+        return (
+            self.initial_height
+            + (self.magnet_depth if self.magnet_choice else 0)
+            + (0.8 if self.nfc_choice else 0)
+        )
+
+    def get_final_height(self) -> float:
+        """Total height including the design layer (0.6 mm unless inset)."""
+        return self.get_card_height() + (0.6 if not self.inset_choice else 0)
 
     # Scene setup tracking
     scene_setup: BoolProperty(
@@ -487,6 +330,20 @@ class NFCCardProperties(PropertyGroup):
         description="Add an inset design to the card",
         default=False,
         update=update_inset_choice,
+    )
+
+    design_boolean_solver: EnumProperty(
+        name="Boolean Solver",
+        description=(
+            "Boolean solver for design placement. "
+            "Manifold is faster but Exact handles problematic geometry better"
+        ),
+        items=[
+            ("MANIFOLD", "Manifold", "Fast solver, works well with clean geometry"),
+            ("EXACT", "Exact", "Slower but more robust for complex or self-intersecting shapes"),
+        ],
+        default="MANIFOLD",
+        update=update_design_boolean_solver,
     )
 
     # Design 1 properties
@@ -1059,13 +916,12 @@ class NFCCardProperties(PropertyGroup):
         name="QR Module Style 1",
         description="Shape style for QR code data modules",
         items=[
-            # NOTE: SQUARE option removed - causes non-manifold geometry issues with BMesh processing
-            # ("SQUARE", "Square", "Standard square modules"),
+            ("SQUARE", "Square", "Standard square modules"),
             ("ROUNDED", "Rounded", "Adaptive rounded corners for organic flow"),
             ("CIRCLE", "Circle", "Circular modules"),
             ("SQUIRCLE", "Squircle", "Super-ellipse modules"),
         ],
-        default="ROUNDED",  # Changed from SQUARE - more reliable with BMesh processing
+        default="ROUNDED",
     )
 
     qr_finder_style_1: bpy.props.EnumProperty(
@@ -1095,13 +951,12 @@ class NFCCardProperties(PropertyGroup):
         name="QR Module Style 2",
         description="Shape style for QR code data modules",
         items=[
-            # NOTE: SQUARE option removed - causes non-manifold geometry issues with BMesh processing
-            # ("SQUARE", "Square", "Standard square modules"),
+            ("SQUARE", "Square", "Standard square modules"),
             ("ROUNDED", "Rounded", "Adaptive rounded corners for organic flow"),
             ("CIRCLE", "Circle", "Circular modules"),
             ("SQUIRCLE", "Squircle", "Super-ellipse modules"),
         ],
-        default="ROUNDED",  # Changed from SQUARE - more reliable with BMesh processing
+        default="ROUNDED",
     )
 
     qr_finder_style_2: bpy.props.EnumProperty(

--- a/nfcCardGen/qr_generator.py
+++ b/nfcCardGen/qr_generator.py
@@ -8,14 +8,14 @@ This module handles generating different types of QR codes using the segno libra
 - Email QR codes for pre-filled email messages
 """
 
-import os
+import math
 import traceback
 from typing import Optional
 
 import bmesh
 import bpy
-import numpy as np
-from bpy.types import Material, Object, Operator
+from bpy.types import Object, Operator
+from mathutils import Matrix
 
 try:
     import segno
@@ -32,49 +32,6 @@ except Exception as e:
     helpers = None
 
 
-def _get_temp_svg_path(design_num: int) -> str:
-    """
-    Get a temporary SVG file path for QR code processing.
-
-    Uses the extension's user directory with a unique filename to ensure proper permissions
-    and automatic cleanup. Files are intended to be deleted immediately after use.
-
-    Args:
-        design_num: Which design slot this is for (1 or 2)
-
-    Returns:
-        Full path to the temporary SVG file
-    """
-    import time
-    import random
-
-    temp_dir = bpy.utils.extension_path_user(__package__, path="temp", create=True)
-    # Create unique filename with timestamp and random component to avoid conflicts
-    timestamp = int(time.time() * 1000)  # milliseconds
-    random_id = random.randint(1000, 9999)
-    filename = f"qr_design_{design_num}_{timestamp}_{random_id}.svg"
-    return os.path.join(temp_dir, filename)
-
-
-def _cleanup_old_temp_files() -> None:
-    """
-    Clean up any old temporary SVG files that may have been left behind.
-
-    This is called during addon initialization to ensure no accumulation
-    of temporary files over time.
-    """
-    try:
-        temp_dir = bpy.utils.extension_path_user(__package__, path="temp", create=False)
-        if os.path.exists(temp_dir):
-            for filename in os.listdir(temp_dir):
-                if filename.startswith("qr_design_") and filename.endswith(".svg"):
-                    file_path = os.path.join(temp_dir, filename)
-                    try:
-                        os.unlink(file_path)
-                    except Exception:
-                        pass  # Ignore errors when cleaning up
-    except Exception:
-        pass  # Ignore errors if temp directory doesn't exist or can't be accessed
 
 
 class QRCodeGenerator:
@@ -121,6 +78,11 @@ class QRCodeGenerator:
             return None
 
         try:
+            # Validate content length to prevent impractically large QR codes
+            if len(content) > 2000:
+                print(f"QR content too long ({len(content)} chars, max 2000).")
+                return None
+
             # Create standard QR code - segno automatically optimizes encoding
             qr = segno.make_qr(content, error=error_correction)
             return qr
@@ -312,185 +274,6 @@ class QRCodeGenerator:
             print(f"Unknown QR code type: {qr_type}")
             return None
 
-    @classmethod
-    def create_qr_mesh_from_data(
-        cls, qr_data: segno.QRCode, size: float = 0.02
-    ) -> Optional[Object]:
-        """
-        Convert QR code data into a 3D mesh object.
-
-        This creates a mesh where each QR code module (pixel) becomes a small cube.
-
-        Args:
-            qr_data: QR code data from segno.
-            size: Size of the QR code in Blender units.
-
-        Returns:
-            Created mesh object, or None if conversion failed.
-        """
-        if not qr_data:
-            return None
-
-        matrix = [list(row) for row in qr_data.matrix]
-        qr_size = len(matrix)
-        module_size = size / qr_size
-
-        mesh = bpy.data.meshes.new("QR_Code")
-        qr_object = bpy.data.objects.new("QR_Code", mesh)
-        bpy.context.collection.objects.link(qr_object)
-
-        bm = bmesh.new()
-
-        try:
-            for row_idx, row in enumerate(matrix):
-                for col_idx, is_dark in enumerate(row):
-                    if is_dark:
-                        x = (col_idx - qr_size / 2) * module_size
-                        y = (row_idx - qr_size / 2) * module_size
-                        z = 0
-
-                        # 0.9 scale creates small gaps between modules for better definition
-                        bmesh.ops.create_cube(
-                            bm,
-                            size=module_size * 0.9,
-                            matrix=bpy.utils.Matrix.Translation((x, y, z)),
-                        )
-
-            bm.to_mesh(mesh)
-            mesh.update()
-
-            return qr_object
-
-        except Exception as e:
-            print(f"QR mesh creation failed: {e}")
-            return None
-
-        finally:
-            bm.free()
-
-    @staticmethod
-    def create_qr_material(name: str = "QR_Code_Material") -> Material:
-        """
-        Create a material suitable for QR codes.
-
-        Args:
-            name: Name for the created material.
-
-        Returns:
-            The created material.
-        """
-        material = bpy.data.materials.new(name=name)
-        material.use_nodes = True
-
-        nodes = material.node_tree.nodes
-        nodes.clear()
-
-        bsdf = nodes.new(type="ShaderNodeBsdfPrincipled")
-        output = nodes.new(type="ShaderNodeOutputMaterial")
-
-        # Dark, matte material ensures good contrast and scannability
-        bsdf.inputs["Base Color"].default_value = (0.05, 0.05, 0.05, 1.0)
-        bsdf.inputs["Metallic"].default_value = 0.0
-        bsdf.inputs["Roughness"].default_value = 0.9
-
-        material.node_tree.links.new(bsdf.outputs["BSDF"], output.inputs["Surface"])
-
-        bsdf.location = (0, 0)
-        output.location = (200, 0)
-
-        return material
-
-    @classmethod
-    def prepare_qr_for_card(cls, qr_object: Object, target_size: float = 0.025) -> None:
-        """
-        Prepare QR code object for card placement by scaling it appropriately.
-
-        Positioning is handled by the geometry node system.
-
-        Args:
-            qr_object: The QR code mesh object.
-            target_size: Target size for the QR code in meters (default 25mm).
-        """
-        if not qr_object:
-            return
-
-        bbox_corners = [
-            qr_object.matrix_world @ vertex.co for vertex in qr_object.bound_box
-        ]
-        current_size = max(
-            max(corner.x for corner in bbox_corners)
-            - min(corner.x for corner in bbox_corners),
-            max(corner.y for corner in bbox_corners)
-            - min(corner.y for corner in bbox_corners),
-        )
-
-        if current_size > 0:
-            scale_factor = target_size / current_size
-            qr_object.scale = (scale_factor, scale_factor, scale_factor)
-
-        qr_object.location = (0, 0, 0)
-        qr_object.name = "QR_Code"
-
-
-def generate_qr_for_card(qr_type: str, **qr_params) -> Optional[Object]:
-    """
-    Convenience function to generate any type of QR code for card placement.
-
-    Args:
-        qr_type: Type of QR code ('TEXT', 'WIFI', 'CONTACT', 'EMAIL').
-        **qr_params: Type-specific parameters for QR generation.
-
-    Returns:
-        Created QR code object, or None if generation failed.
-    """
-    if not QRCodeGenerator.is_segno_available():
-        print("Segno library not available for QR code generation")
-        return None
-
-    qr_data = QRCodeGenerator.generate_qr_by_type(qr_type, **qr_params)
-    if not qr_data:
-        print(f"Failed to generate {qr_type} QR code")
-        return None
-
-    qr_object = QRCodeGenerator.create_qr_mesh_from_data(qr_data, size=0.02)
-    if not qr_object:
-        print("Failed to create QR code mesh")
-        return None
-
-    QRCodeGenerator.prepare_qr_for_card(qr_object)
-    qr_object.name = f"QR_Code_{qr_type}"
-
-    return qr_object
-
-
-def generate_text_qr_for_card(content: str) -> Optional[Object]:
-    """Generate a text/URL QR code for card placement."""
-    return generate_qr_for_card(QRCodeGenerator.QR_TYPE_TEXT, content=content)
-
-
-def generate_wifi_qr_for_card(
-    ssid: str, password: str = "", security: str = "WPA"
-) -> Optional[Object]:
-    """Generate a WiFi QR code for card placement."""
-    return generate_qr_for_card(
-        QRCodeGenerator.QR_TYPE_WIFI, ssid=ssid, password=password, security=security
-    )
-
-
-def generate_contact_qr_for_card(
-    name: str, phone: str = "", email: str = "", url: str = "", org: str = ""
-) -> Optional[Object]:
-    """Generate a contact vCard QR code for card placement."""
-    return generate_qr_for_card(
-        QRCodeGenerator.QR_TYPE_CONTACT,
-        name=name,
-        phone=phone,
-        email=email,
-        url=url,
-        org=org,
-    )
-
-
 class OBJECT_OT_nfc_toggle_qr_mode(Operator):
     """Toggle QR code generation mode for a design slot"""
 
@@ -523,12 +306,14 @@ class OBJECT_OT_nfc_toggle_qr_mode(Operator):
         props = context.scene.nfc_card_props
 
         if self.design_num == 1:
+            was_qr = props.qr_mode_1
             props.qr_mode_1 = self.enable_qr
-            if props.qr_mode_1 != self.enable_qr:
+            if was_qr != self.enable_qr:
                 props.has_design_1 = False
         else:
+            was_qr = props.qr_mode_2
             props.qr_mode_2 = self.enable_qr
-            if props.qr_mode_2 != self.enable_qr:
+            if was_qr != self.enable_qr:
                 props.has_design_2 = False
 
         return {"FINISHED"}
@@ -545,9 +330,251 @@ ROUNDED_CORNER_RADIUS = (
     0.3  # Corner radius for rounded adaptive style (fraction of module size)
 )
 
+# Direct BMesh QR construction constants
+CIRCLE_SEGMENTS = 32       # polygon segments for circle approximation
+BEZIER_SAMPLES = 8         # samples per cubic-Bézier quarter-arc (32 verts/squircle)
+CORNER_ARC_SAMPLES = 6     # samples per quadratic-Bézier rounded corner
+QR_EXTRUDE_HEIGHT = 0.6    # mm – extrusion thickness for QR modules
+QR_TARGET_SIZE = 40.0      # mm – final QR mesh scaled to fit this dimension
+ROUNDED_MERGE_DIST = 0.0001  # vertex merge distance for ROUNDED blob welding
+
+
+# ---------------------------------------------------------------------------
+#  Geometry helpers – polygon vertex generators & BMesh extrusion utilities
+# ---------------------------------------------------------------------------
+
+def _cubic_bezier(p0, p1, p2, p3, t):
+    """Evaluate cubic Bézier at parameter *t* ∈ [0, 1]."""
+    u = 1.0 - t
+    return (
+        u*u*u*p0[0] + 3*u*u*t*p1[0] + 3*u*t*t*p2[0] + t*t*t*p3[0],
+        u*u*u*p0[1] + 3*u*u*t*p1[1] + 3*u*t*t*p2[1] + t*t*t*p3[1],
+    )
+
+
+def _quadratic_bezier(p0, p1, p2, t):
+    """Evaluate quadratic Bézier at parameter *t* ∈ [0, 1]."""
+    u = 1.0 - t
+    return (
+        u*u*p0[0] + 2*u*t*p1[0] + t*t*p2[0],
+        u*u*p0[1] + 2*u*t*p1[1] + t*t*p2[1],
+    )
+
+
+def _square_verts(
+    cx: float, cy: float, half: float,
+) -> list[tuple[float, float]]:
+    """CCW square vertices centred at (*cx*, *cy*)."""
+    return [
+        (cx - half, cy - half),
+        (cx + half, cy - half),
+        (cx + half, cy + half),
+        (cx - half, cy + half),
+    ]
+
+
+def _circle_verts(
+    cx: float, cy: float, radius: float,
+    segments: int = CIRCLE_SEGMENTS,
+) -> list[tuple[float, float]]:
+    """CCW regular polygon approximating a circle."""
+    tau = 2.0 * math.pi
+    return [
+        (cx + radius * math.cos(tau * i / segments),
+         cy + radius * math.sin(tau * i / segments))
+        for i in range(segments)
+    ]
+
+
+def _squircle_verts(
+    cx: float, cy: float, size: float,
+    samples: int = BEZIER_SAMPLES,
+) -> list[tuple[float, float]]:
+    """Super-ellipse (squircle) vertices via cubic-Bézier sampling."""
+    half = size / 2.0
+    d = half * SQUIRCLE_MAGIC_K
+    # Four Bézier quarter-arcs starting at top, going clockwise
+    curves = [
+        ((cx, cy - half), (cx + d, cy - half), (cx + half, cy - d), (cx + half, cy)),
+        ((cx + half, cy), (cx + half, cy + d), (cx + d, cy + half), (cx, cy + half)),
+        ((cx, cy + half), (cx - d, cy + half), (cx - half, cy + d), (cx - half, cy)),
+        ((cx - half, cy), (cx - half, cy - d), (cx - d, cy - half), (cx, cy - half)),
+    ]
+    verts: list[tuple[float, float]] = []
+    for p0, p1, p2, p3 in curves:
+        for i in range(samples):
+            verts.append(_cubic_bezier(p0, p1, p2, p3, i / samples))
+    return verts
+
+
+def _rounded_rect_verts(
+    x: float, y: float, size: float, round_corners: dict,
+    r_frac: float = ROUNDED_CORNER_RADIUS,
+    arc_n: int = CORNER_ARC_SAMPLES,
+) -> list[tuple[float, float]]:
+    """Rectangle with selectively rounded corners.
+
+    *x*, *y* is the top-left corner of the bounding square.
+    *round_corners* maps ``'tl'``, ``'tr'``, ``'br'``, ``'bl'`` → bool.
+    """
+    r = size * r_frac
+    verts: list[tuple[float, float]] = []
+
+    # Start at top-left
+    if round_corners.get("tl"):
+        verts.append((x + r, y))
+    else:
+        verts.append((x, y))
+
+    # Top-right corner
+    if round_corners.get("tr"):
+        p0, p1, p2 = (x + size - r, y), (x + size, y), (x + size, y + r)
+        verts.append(p0)
+        for i in range(1, arc_n + 1):
+            verts.append(_quadratic_bezier(p0, p1, p2, i / arc_n))
+    else:
+        verts.append((x + size, y))
+
+    # Bottom-right corner
+    if round_corners.get("br"):
+        p0 = (x + size, y + size - r)
+        p1 = (x + size, y + size)
+        p2 = (x + size - r, y + size)
+        verts.append(p0)
+        for i in range(1, arc_n + 1):
+            verts.append(_quadratic_bezier(p0, p1, p2, i / arc_n))
+    else:
+        verts.append((x + size, y + size))
+
+    # Bottom-left corner
+    if round_corners.get("bl"):
+        p0 = (x + r, y + size)
+        p1 = (x, y + size)
+        p2 = (x, y + size - r)
+        verts.append(p0)
+        for i in range(1, arc_n + 1):
+            verts.append(_quadratic_bezier(p0, p1, p2, i / arc_n))
+    else:
+        verts.append((x, y + size))
+
+    # Top-left corner (closing arc)
+    if round_corners.get("tl"):
+        p0 = (x, y + r)
+        p1 = (x, y)
+        p2 = (x + r, y)
+        verts.append(p0)
+        for i in range(1, arc_n):  # exclude last – coincides with start vertex
+            verts.append(_quadratic_bezier(p0, p1, p2, i / arc_n))
+
+    return verts
+
+
+def _shape_verts_for_style(
+    cx: float, cy: float, size: float, style: str,
+) -> list[tuple[float, float]]:
+    """Return polygon vertices for a shape *style* (no module scale applied)."""
+    half = size / 2.0
+    if style == "SQUARE":
+        return _square_verts(cx, cy, half)
+    if style == "CIRCLE":
+        return _circle_verts(cx, cy, half)
+    if style == "SQUIRCLE":
+        return _squircle_verts(cx, cy, size)
+    return _square_verts(cx, cy, half)  # fallback
+
+
+def _module_verts_for_style(
+    cx: float, cy: float, size: float, style: str,
+    round_corners: dict | None = None,
+) -> list[tuple[float, float]]:
+    """Return polygon vertices for a single QR module with MODULE_SCALE_FACTOR gap."""
+    scaled = size * MODULE_SCALE_FACTOR
+    half_s = scaled / 2.0
+    if style == "SQUARE":
+        return _square_verts(cx, cy, half_s)
+    if style == "CIRCLE":
+        return _circle_verts(cx, cy, half_s)
+    if style == "SQUIRCLE":
+        return _squircle_verts(cx, cy, scaled)
+    if style == "ROUNDED":
+        if round_corners and any(round_corners.values()):
+            return _rounded_rect_verts(
+                cx - half_s, cy - half_s, scaled, round_corners,
+            )
+        return _square_verts(cx, cy, half_s)
+    return _square_verts(cx, cy, half_s)  # fallback
+
+
+def _create_flat_face(
+    bm: bmesh.types.BMesh,
+    verts_2d: list[tuple[float, float]],
+    z: float = 0.0,
+) -> None:
+    """Create a single flat face at height *z* from 2-D polygon vertices."""
+    n = len(verts_2d)
+    if n < 3:
+        return
+    bm.faces.new([bm.verts.new((x, y, z)) for x, y in verts_2d])
+
+
+def _extrude_polygon(
+    bm: bmesh.types.BMesh,
+    verts_2d: list[tuple[float, float]],
+    z_bot: float = 0.0,
+    z_top: float = QR_EXTRUDE_HEIGHT,
+) -> None:
+    """Create a closed extruded solid from a 2-D polygon outline.
+
+    Builds bottom face, top face and side quads – guaranteed manifold when
+    the polygon is non-self-intersecting.
+    """
+    n = len(verts_2d)
+    if n < 3:
+        return
+    bot = [bm.verts.new((x, y, z_bot)) for x, y in verts_2d]
+    top = [bm.verts.new((x, y, z_top)) for x, y in verts_2d]
+    # Bottom face – reversed winding so normal points −Z
+    bm.faces.new(bot[::-1])
+    # Top face – normal points +Z
+    bm.faces.new(top)
+    # Side quads
+    for i in range(n):
+        j = (i + 1) % n
+        bm.faces.new([bot[i], bot[j], top[j], top[i]])
+
+
+def _extrude_ring(
+    bm: bmesh.types.BMesh,
+    outer: list[tuple[float, float]],
+    inner: list[tuple[float, float]],
+    z_bot: float = 0.0,
+    z_top: float = QR_EXTRUDE_HEIGHT,
+) -> None:
+    """Create a closed extruded annular ring (outer shell with inner hole).
+
+    Both polygons must have the **same** vertex count and consistent winding.
+    """
+    n = len(outer)
+    if n < 3 or len(inner) != n:
+        return
+    ob = [bm.verts.new((x, y, z_bot)) for x, y in outer]
+    ot = [bm.verts.new((x, y, z_top)) for x, y in outer]
+    ib = [bm.verts.new((x, y, z_bot)) for x, y in inner]
+    it_ = [bm.verts.new((x, y, z_top)) for x, y in inner]
+    for i in range(n):
+        j = (i + 1) % n
+        # Top annular quad
+        bm.faces.new([ot[i], ot[j], it_[j], it_[i]])
+        # Bottom annular quad (reversed winding)
+        bm.faces.new([ob[j], ob[i], ib[i], ib[j]])
+        # Outer side face
+        bm.faces.new([ob[i], ob[j], ot[j], ot[i]])
+        # Inner side face (inward-pointing normal)
+        bm.faces.new([ib[j], ib[i], it_[i], it_[j]])
+
 
 class OBJECT_OT_nfc_generate_qr(Operator):
-    """Generate a QR code and process it through the SVG pipeline"""
+    """Generate a QR code and build it directly as manifold BMesh geometry"""
 
     bl_idname = "object.nfc_generate_qr"
     bl_label = "Generate QR Code"
@@ -571,46 +598,26 @@ class OBJECT_OT_nfc_generate_qr(Operator):
 
     def _get_qr_settings(self, props, design_num: int):
         """Helper to get QR settings for a design slot."""
-        if design_num == 1:
-            return {
-                "qr_type": props.qr_type_1,
-                "error_correction": props.qr_error_correction_1,
-                "text_content": props.qr_text_content_1,
-                "wifi_ssid": props.qr_wifi_ssid_1,
-                "wifi_password": props.qr_wifi_password_1,
-                "wifi_security": props.qr_wifi_security_1,
-                "wifi_hidden": props.qr_wifi_hidden_1,
-                "contact_name": props.qr_contact_name_1,
-                "contact_phone": props.qr_contact_phone_1,
-                "contact_email": props.qr_contact_email_1,
-                "contact_url": props.qr_contact_url_1,
-                "contact_org": props.qr_contact_org_1,
-                "email_to": props.qr_email_to_1,
-                "email_cc": props.qr_email_cc_1,
-                "email_bcc": props.qr_email_bcc_1,
-                "email_subject": props.qr_email_subject_1,
-                "email_body": props.qr_email_body_1,
-            }
-        else:
-            return {
-                "qr_type": props.qr_type_2,
-                "error_correction": props.qr_error_correction_2,
-                "text_content": props.qr_text_content_2,
-                "wifi_ssid": props.qr_wifi_ssid_2,
-                "wifi_password": props.qr_wifi_password_2,
-                "wifi_security": props.qr_wifi_security_2,
-                "wifi_hidden": props.qr_wifi_hidden_2,
-                "contact_name": props.qr_contact_name_2,
-                "contact_phone": props.qr_contact_phone_2,
-                "contact_email": props.qr_contact_email_2,
-                "contact_url": props.qr_contact_url_2,
-                "contact_org": props.qr_contact_org_2,
-                "email_to": props.qr_email_to_2,
-                "email_cc": props.qr_email_cc_2,
-                "email_bcc": props.qr_email_bcc_2,
-                "email_subject": props.qr_email_subject_2,
-                "email_body": props.qr_email_body_2,
-            }
+        s = str(design_num)
+        return {
+            "qr_type": getattr(props, f"qr_type_{s}"),
+            "error_correction": getattr(props, f"qr_error_correction_{s}"),
+            "text_content": getattr(props, f"qr_text_content_{s}"),
+            "wifi_ssid": getattr(props, f"qr_wifi_ssid_{s}"),
+            "wifi_password": getattr(props, f"qr_wifi_password_{s}"),
+            "wifi_security": getattr(props, f"qr_wifi_security_{s}"),
+            "wifi_hidden": getattr(props, f"qr_wifi_hidden_{s}"),
+            "contact_name": getattr(props, f"qr_contact_name_{s}"),
+            "contact_phone": getattr(props, f"qr_contact_phone_{s}"),
+            "contact_email": getattr(props, f"qr_contact_email_{s}"),
+            "contact_url": getattr(props, f"qr_contact_url_{s}"),
+            "contact_org": getattr(props, f"qr_contact_org_{s}"),
+            "email_to": getattr(props, f"qr_email_to_{s}"),
+            "email_cc": getattr(props, f"qr_email_cc_{s}"),
+            "email_bcc": getattr(props, f"qr_email_bcc_{s}"),
+            "email_subject": getattr(props, f"qr_email_subject_{s}"),
+            "email_body": getattr(props, f"qr_email_body_{s}"),
+        }
 
     def _build_qr_params(self, qr_type: str, settings: dict):
         """Helper to build QR parameters based on type."""
@@ -666,7 +673,7 @@ class OBJECT_OT_nfc_generate_qr(Operator):
         return qr_params, None
 
     def execute(self, context):
-        """Generate QR code and process it."""
+        """Generate QR code, build it as direct BMesh geometry, and connect to nodes."""
         props = context.scene.nfc_card_props
 
         settings = self._get_qr_settings(props, self.design_num)
@@ -683,36 +690,54 @@ class OBJECT_OT_nfc_generate_qr(Operator):
             return {"CANCELLED"}
 
         try:
-            # Get extension-specific temp file path for SVG processing
-            temp_svg_path = _get_temp_svg_path(self.design_num)
-
             matrix = [list(row) for row in qr_code.matrix]
-            svg_content = self._create_qr_svg(matrix, len(matrix), 1.0)
+            qr_size = len(matrix)
 
-            with open(temp_svg_path, "w") as f:
-                f.write(svg_content)
-
-            from . import svg_import
-
-            success = svg_import.process_svg_to_mesh(
-                temp_svg_path, self.design_num, self.report
-            )
-
-            if success:
-                if self.design_num == 1:
-                    props.has_design_1 = True
-                else:
-                    props.has_design_2 = True
+            # Read style settings for this design slot
+            if self.design_num == 1:
+                module_style = props.qr_module_style_1
+                finder_style = props.qr_finder_style_1
             else:
-                self.report({"ERROR"}, "Failed to process QR code SVG")
+                module_style = props.qr_module_style_2
+                finder_style = props.qr_finder_style_2
+
+            finder_border_style = self._determine_border_style(finder_style)
+
+            # Build mesh directly via BMesh – no SVG intermediary
+            design_obj = self._build_qr_mesh(
+                matrix, qr_size, module_style, finder_style, finder_border_style,
+            )
+            if not design_obj:
+                self.report({"ERROR"}, "Failed to build QR code mesh")
                 return {"CANCELLED"}
 
-            # Clean up temporary SVG file
-            try:
-                if os.path.exists(temp_svg_path):
-                    os.unlink(temp_svg_path)
-            except Exception:
-                pass
+            # Connect to geometry-node setup
+            from . import svg_import
+
+            logo_placer = svg_import._find_logo_placer_node_group()
+            if not logo_placer:
+                bpy.data.objects.remove(design_obj, do_unlink=True)
+                self.report(
+                    {"ERROR"},
+                    "Logo Placer node group not found. Ensure the scene is set up.",
+                )
+                return {"CANCELLED"}
+
+            design_input = svg_import._find_design_input_node(
+                logo_placer, self.design_num,
+            )
+            if not design_input:
+                bpy.data.objects.remove(design_obj, do_unlink=True)
+                self.report({"ERROR"}, "Design input node not found.")
+                return {"CANCELLED"}
+
+            design_input.inputs[0].default_value = design_obj
+            design_obj.hide_viewport = True
+
+            if self.design_num == 1:
+                props.has_design_1 = True
+            else:
+                props.has_design_2 = True
 
         except Exception as e:
             traceback.print_exc()
@@ -721,254 +746,179 @@ class OBJECT_OT_nfc_generate_qr(Operator):
 
         return {"FINISHED"}
 
-    def _create_qr_svg(self, matrix, qr_size: int, module_size: float) -> str:
-        """Create SVG content from QR matrix with custom styling."""
-        props = bpy.context.scene.nfc_card_props
+    # ------------------------------------------------------------------
+    #  Direct BMesh QR mesh construction
+    # ------------------------------------------------------------------
 
-        if self.design_num == 1:
-            module_style = props.qr_module_style_1
-            finder_style = props.qr_finder_style_1
-        else:
-            module_style = props.qr_module_style_2
-            finder_style = props.qr_finder_style_2
+    def _build_qr_mesh(
+        self, matrix, qr_size: int,
+        module_style: str, finder_style: str, finder_border_style: str,
+    ) -> Optional[Object]:
+        """Build the full QR code as a manifold mesh directly in BMesh.
 
-        finder_border_style = self._determine_border_style(finder_style)
-        svg_width = qr_size * module_size
-        svg_height = qr_size * module_size
+        For SQUARE / CIRCLE / SQUIRCLE each module is independently extruded
+        with a MODULE_SCALE_FACTOR gap – guaranteed manifold by construction.
+
+        For ROUNDED the modules are placed at full size so adjacent dark
+        cells merge into continuous blobs with only the exposed corners
+        rounded.  The flat faces are welded, extruded as one, then cleaned.
+        """
+        module_size = QR_TARGET_SIZE / qr_size
         finder_positions = self._get_finder_positions(qr_size)
 
-        # Pre-analyze neighbors for rounded style (batch operation)
-        corner_map = {}
-        if module_style == "ROUNDED":
-            corner_map = self._analyze_neighbors(matrix)
+        mesh = bpy.data.meshes.new(f"QR_Design_{self.design_num}")
+        obj = bpy.data.objects.new(f"Design_{self.design_num}_QR", mesh)
+        bpy.context.collection.objects.link(obj)
 
-        svg_content = f'''<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="{svg_width}" height="{svg_height}" viewBox="0 0 {svg_width} {svg_height}">
-'''
+        bm = bmesh.new()
+        try:
+            if module_style == "ROUNDED":
+                self._build_rounded_blobs(
+                    bm, matrix, qr_size, module_size, finder_positions,
+                )
+            else:
+                # --- per-module extrusion (SQUARE / CIRCLE / SQUIRCLE) ---
+                for row_idx, row in enumerate(matrix):
+                    for col_idx, is_dark in enumerate(row):
+                        if not is_dark:
+                            continue
+                        if self._is_in_finder_area(
+                            row_idx, col_idx, finder_positions,
+                        ):
+                            continue
+                        cx = (col_idx - qr_size / 2 + 0.5) * module_size
+                        cy = (row_idx - qr_size / 2 + 0.5) * module_size
+                        verts = _module_verts_for_style(
+                            cx, cy, module_size, module_style, None,
+                        )
+                        _extrude_polygon(bm, verts)
 
-        for finder_pos in finder_positions:
-            svg_content += self._create_finder_pattern(
-                finder_pos, module_size, finder_style, finder_border_style
+            # --- finder patterns (border ring + centre fill) ---
+            for fp in finder_positions:
+                self._build_finder_bmesh(
+                    bm, fp, module_size, qr_size,
+                    finder_style, finder_border_style,
+                )
+
+            # Centre origin in Z so the mesh spans −height/2 … +height/2
+            z_offset = -QR_EXTRUDE_HEIGHT / 2.0
+            bmesh.ops.transform(
+                bm,
+                matrix=Matrix.Translation((0, 0, z_offset)),
+                verts=bm.verts,
             )
 
+            # Ensure consistent outward normals
+            bmesh.ops.recalc_face_normals(bm, faces=bm.faces)
+            bm.to_mesh(mesh)
+            mesh.update()
+
+        except Exception:
+            bpy.data.objects.remove(obj, do_unlink=True)
+            raise
+        finally:
+            bm.free()
+
+        return obj
+
+    def _build_rounded_blobs(
+        self, bm, matrix, qr_size: int, module_size: float,
+        finder_positions: list,
+    ) -> None:
+        """Build ROUNDED-style data modules as continuous merged blobs.
+
+        1. Place each dark module as a **full-size** rounded-rect flat face
+           (corners without cardinal neighbours are rounded, others are sharp).
+        2. Weld coincident vertices so adjacent modules share edges.
+        3. Extrude the connected flat mesh upward.
+        4. Clean up interior faces and recalculate normals.
+        """
+        corner_map = self._analyze_neighbors(matrix)
+        half = module_size / 2.0
+
+        # --- lay down flat faces at z = 0 ---------------------------------
         for row_idx, row in enumerate(matrix):
             for col_idx, is_dark in enumerate(row):
-                if is_dark and not self._is_in_finder_area(
-                    row_idx, col_idx, finder_positions
-                ):
-                    x = col_idx * module_size
-                    y = row_idx * module_size
+                if not is_dark:
+                    continue
+                if self._is_in_finder_area(row_idx, col_idx, finder_positions):
+                    continue
 
-                    # Pass corner info for rounded style
-                    corners = corner_map.get((row_idx, col_idx), None)
-                    svg_content += self._create_shape(
-                        x, y, module_size, module_style, corners
+                cx = (col_idx - qr_size / 2 + 0.5) * module_size
+                cy = (row_idx - qr_size / 2 + 0.5) * module_size
+
+                corners = corner_map.get((row_idx, col_idx))
+                if corners and any(corners.values()):
+                    verts = _rounded_rect_verts(
+                        cx - half, cy - half, module_size, corners,
                     )
+                else:
+                    verts = _square_verts(cx, cy, half)
+                _create_flat_face(bm, verts)
 
-        svg_content += "</svg>"
-        return svg_content
+        # --- merge shared edges between adjacent modules ------------------
+        bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=ROUNDED_MERGE_DIST)
 
-    def _determine_border_style(self, finder_style: str) -> str:
-        """Determine border style based on finder center style."""
-        if finder_style in ("SQUARE", "CIRCLE"):
-            return finder_style
-        return "SQUIRCLE"
-
-    def _get_finder_positions(self, qr_size: int) -> list:
-        """Get positions of the three finder patterns."""
-        offset = FINDER_PATTERN_SIZE // 2
-        return [
-            {"row": offset, "col": offset},
-            {"row": offset, "col": qr_size - offset - 1},
-            {"row": qr_size - offset - 1, "col": offset},
+        # --- extrude the connected flat faces upward ----------------------
+        faces = bm.faces[:]
+        extruded = bmesh.ops.extrude_face_region(bm, geom=faces)
+        ext_verts = [
+            v for v in extruded["geom"] if isinstance(v, bmesh.types.BMVert)
         ]
-
-    def _is_in_finder_area(self, row: int, col: int, finder_positions: list) -> bool:
-        """Check if a module is within any finder pattern area."""
-        half_size = FINDER_PATTERN_SIZE // 2
-        for finder in finder_positions:
-            if (
-                abs(row - finder["row"]) <= half_size
-                and abs(col - finder["col"]) <= half_size
-            ):
-                return True
-        return False
-
-    def _analyze_neighbors(self, matrix) -> dict:
-        """Analyze QR matrix to determine which corners should be rounded.
-
-        Uses NumPy array slicing for efficient neighbor detection.
-        Returns dict mapping (row, col) to rounded corner flags.
-        """
-        arr = np.array(matrix, dtype=bool)
-        height, width = arr.shape
-        padded = np.pad(arr, pad_width=1, mode="constant", constant_values=False)
-
-        north = padded[:-2, 1:-1]
-        south = padded[2:, 1:-1]
-        west = padded[1:-1, :-2]
-        east = padded[1:-1, 2:]
-
-        corners = {}
-        filled = np.argwhere(arr)
-
-        for row, col in filled:
-            round_corners = {
-                "tl": not north[row, col] and not west[row, col],
-                "tr": not north[row, col] and not east[row, col],
-                "br": not south[row, col] and not east[row, col],
-                "bl": not south[row, col] and not west[row, col],
-            }
-            if any(round_corners.values()):
-                corners[(row, col)] = round_corners
-
-        return corners
-
-    def _create_rounded_rect_path(
-        self, x: float, y: float, size: float, round_corners: dict
-    ) -> str:
-        """Create SVG path for rectangle with adaptive rounded corners."""
-        r = size * ROUNDED_CORNER_RADIUS
-        start_x = x + (r if round_corners["tl"] else 0)
-
-        path = f"M {start_x},{y} "
-
-        if round_corners["tr"]:
-            path += f"L {x + size - r},{y} Q {x + size},{y} {x + size},{y + r} "
-        else:
-            path += f"L {x + size},{y} "
-
-        if round_corners["br"]:
-            path += f"L {x + size},{y + size - r} Q {x + size},{y + size} {x + size - r},{y + size} "
-        else:
-            path += f"L {x + size},{y + size} "
-
-        if round_corners["bl"]:
-            path += f"L {x + r},{y + size} Q {x},{y + size} {x},{y + size - r} "
-        else:
-            path += f"L {x},{y + size} "
-
-        if round_corners["tl"]:
-            path += f"L {x},{y + r} Q {x},{y} {x + r},{y} "
-        else:
-            path += f"L {x},{y} "
-
-        path += "z"
-        return path
-
-    def _create_squircle_path(self, cx: float, cy: float, size: float) -> str:
-        """Generate SVG path for a squircle (super-ellipse)."""
-        half = size / 2
-        d = half * SQUIRCLE_MAGIC_K
-
-        path = f"M {cx},{cy - half} "
-        path += f"C {cx + d},{cy - half} {cx + half},{cy - d} {cx + half},{cy} "
-        path += f"C {cx + half},{cy + d} {cx + d},{cy + half} {cx},{cy + half} "
-        path += f"C {cx - d},{cy + half} {cx - half},{cy + d} {cx - half},{cy} "
-        path += f"C {cx - half},{cy - d} {cx - d},{cy - half} {cx},{cy - half} z"
-        return path
-
-    def _create_finder_pattern(
-        self, finder_pos: dict, module_size: float, center_style: str, border_style: str
-    ) -> str:
-        """Create a complete finder pattern as cohesive shapes."""
-        row = finder_pos["row"]
-        col = finder_pos["col"]
-        half_size = FINDER_PATTERN_SIZE // 2
-        half_center = FINDER_CENTER_SIZE // 2
-
-        center_x = (col - half_center) * module_size
-        center_y = (row - half_center) * module_size
-        center_size = FINDER_CENTER_SIZE * module_size
-
-        border_x = (col - half_size) * module_size
-        border_y = (row - half_size) * module_size
-        border_outer_size = FINDER_PATTERN_SIZE * module_size
-        border_inner_size = (FINDER_PATTERN_SIZE - 2) * module_size
-        border_inner_x = border_x + module_size
-        border_inner_y = border_y + module_size
-
-        svg_content = ""
-
-        if border_style == "SQUARE":
-            svg_content += '<path fill-rule="evenodd" fill="black" d="'
-            svg_content += f"M {border_x},{border_y} h {border_outer_size} v {border_outer_size} h -{border_outer_size} z "
-            svg_content += f"M {border_inner_x},{border_inner_y} h {border_inner_size} v {border_inner_size} h -{border_inner_size} z"
-            svg_content += '"/>\n'
-
-        elif border_style == "CIRCLE":
-            cx = border_x + border_outer_size / 2
-            cy = border_y + border_outer_size / 2
-            outer_r = border_outer_size / 2
-            inner_r = border_inner_size / 2
-            svg_content += '<path fill-rule="evenodd" fill="black" d="'
-            svg_content += f"M {cx - outer_r},{cy} a {outer_r},{outer_r} 0 1,0 {outer_r * 2},0 a {outer_r},{outer_r} 0 1,0 -{outer_r * 2},0 z "
-            svg_content += f"M {cx - inner_r},{cy} a {inner_r},{inner_r} 0 1,1 {inner_r * 2},0 a {inner_r},{inner_r} 0 1,1 -{inner_r * 2},0 z"
-            svg_content += '"/>\n'
-
-        elif border_style == "SQUIRCLE":
-            outer_cx = border_x + border_outer_size / 2
-            outer_cy = border_y + border_outer_size / 2
-            inner_cx = border_inner_x + border_inner_size / 2
-            inner_cy = border_inner_y + border_inner_size / 2
-
-            svg_content += '<path fill-rule="evenodd" fill="black" d="'
-            svg_content += (
-                self._create_squircle_path(outer_cx, outer_cy, border_outer_size) + " "
-            )
-            svg_content += self._create_squircle_path(
-                inner_cx, inner_cy, border_inner_size
-            )
-            svg_content += '"/>\n'
-
-        svg_content += self._create_large_shape(
-            center_x, center_y, center_size, center_style
+        bmesh.ops.transform(
+            bm,
+            matrix=Matrix.Translation((0, 0, QR_EXTRUDE_HEIGHT)),
+            verts=ext_verts,
         )
 
-        return svg_content
+        # --- clean up coplanar faces & duplicate verts --------------------
+        bmesh.ops.dissolve_limit(
+            bm,
+            angle_limit=0.085,
+            verts=bm.verts,
+            edges=bm.edges,
+            delimit={"NORMAL"},
+        )
+        bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=ROUNDED_MERGE_DIST)
 
-    def _create_large_shape(self, x: float, y: float, size: float, style: str) -> str:
-        """Create a shape for finder pattern centers (3x3 area)."""
-        cx = x + size / 2
-        cy = y + size / 2
+        # --- remove interior faces created by the extrude -----------------
+        from .svg_import import _select_interior_faces
 
-        if style == "SQUARE":
-            return (
-                f'<rect x="{x}" y="{y}" width="{size}" height="{size}" fill="black"/>\n'
-            )
-        elif style == "CIRCLE":
-            return f'<circle cx="{cx}" cy="{cy}" r="{size / 2}" fill="black"/>\n'
-        elif style == "SQUIRCLE":
-            return (
-                f'<path fill="black" d="{self._create_squircle_path(cx, cy, size)}"/>\n'
-            )
+        interior = _select_interior_faces(bm)
+        if interior:
+            bmesh.ops.delete(bm, geom=interior, context="FACES")
 
-        return f'<rect x="{x}" y="{y}" width="{size}" height="{size}" fill="black"/>\n'
+        # Second dissolve pass + normals
+        bmesh.ops.dissolve_limit(
+            bm,
+            angle_limit=0.085,
+            use_dissolve_boundaries=False,
+            verts=bm.verts,
+            edges=bm.edges,
+            delimit={"NORMAL"},
+        )
+        bmesh.ops.recalc_face_normals(bm, faces=bm.faces)
 
-    def _create_shape(
-        self, x: float, y: float, size: float, style: str, round_corners: dict = None
-    ) -> str:
-        """Create an SVG shape for individual QR modules."""
-        cx = x + size / 2
-        cy = y + size / 2
+    def _build_finder_bmesh(
+        self, bm, finder_pos: dict, module_size: float, qr_size: int,
+        center_style: str, border_style: str,
+    ) -> None:
+        """Add one finder pattern (border ring + centre fill) to *bm*."""
+        fcx = (finder_pos["col"] - qr_size / 2 + 0.5) * module_size
+        fcy = (finder_pos["row"] - qr_size / 2 + 0.5) * module_size
 
-        if style == "SQUARE":
-            return (
-                f'<rect x="{x}" y="{y}" width="{size}" height="{size}" fill="black"/>\n'
-            )
-        elif style == "CIRCLE":
-            scaled_r = size / 2 * MODULE_SCALE_FACTOR
-            return f'<circle cx="{cx}" cy="{cy}" r="{scaled_r}" fill="black"/>\n'
-        elif style == "SQUIRCLE":
-            scaled_size = size * MODULE_SCALE_FACTOR
-            return f'<path fill="black" d="{self._create_squircle_path(cx, cy, scaled_size)}"/>\n'
-        elif style == "ROUNDED":
-            if round_corners and any(round_corners.values()):
-                return f'<path fill="black" d="{self._create_rounded_rect_path(x, y, size, round_corners)}"/>\n'
-            else:
-                return f'<rect x="{x}" y="{y}" width="{size}" height="{size}" fill="black"/>\n'
+        outer_size = FINDER_PATTERN_SIZE * module_size   # 7 modules
+        inner_size = (FINDER_PATTERN_SIZE - 2) * module_size  # 5 modules
+        center_size = FINDER_CENTER_SIZE * module_size    # 3 modules
 
-        return f'<rect x="{x}" y="{y}" width="{size}" height="{size}" fill="black"/>\n'
+        # Border ring – same style for outer and inner ensures equal vertex count
+        outer_v = _shape_verts_for_style(fcx, fcy, outer_size, border_style)
+        inner_v = _shape_verts_for_style(fcx, fcy, inner_size, border_style)
+        _extrude_ring(bm, outer_v, inner_v)
+
+        # Centre fill
+        center_v = _shape_verts_for_style(fcx, fcy, center_size, center_style)
+        _extrude_polygon(bm, center_v)
 
 
 def register() -> None:
@@ -977,9 +927,6 @@ def register() -> None:
             "Warning: segno library not available. QR code generation will be disabled."
         )
         print("To enable QR codes, install the segno wheel in the add-on directory.")
-
-    # Clean up any old temporary files from previous sessions
-    _cleanup_old_temp_files()
 
     bpy.utils.register_class(OBJECT_OT_nfc_toggle_qr_mode)
     bpy.utils.register_class(OBJECT_OT_nfc_generate_qr)

--- a/nfcCardGen/svg_import.py
+++ b/nfcCardGen/svg_import.py
@@ -12,6 +12,14 @@ import bmesh
 import bpy
 from bpy.types import Operator
 from mathutils import Matrix
+from mathutils.bvhtree import BVHTree
+
+# Constants for mesh processing
+EXTRUDE_HEIGHT = 0.6          # mm – thickness of SVG extrusion
+DISSOLVE_ANGLE = 0.084726646  # ~5 degrees in radians
+MAX_DESIGN_SIZE = 40.0        # mm – designs are scaled to fit within this
+MERGE_DISTANCE = 0.0001       # distance threshold for remove_doubles
+MAX_MESH_VERTS = 500_000      # safety limit for imported SVG vertex count
 
 
 def _process_mesh_geometry(design_obj):
@@ -32,25 +40,24 @@ def _process_mesh_geometry(design_obj):
     bm = bmesh.new()
     bm.from_mesh(mesh)
     faces = bm.faces[:]
-    ANGLE = 0.084726646  # ~5 degrees in radians
 
-    # Extrude faces upwards by 0.6mm
+    # Extrude faces upwards
     extruded_faces = bmesh.ops.extrude_face_region(bm, geom=faces)
     bmesh.ops.transform(
         bm,
-        matrix=Matrix.Translation((0, 0, 0.6)),
+        matrix=Matrix.Translation((0, 0, EXTRUDE_HEIGHT)),
         verts=[v for v in extruded_faces["geom"] if isinstance(v, bmesh.types.BMVert)],
     )
 
     # Limited dissolve and merge by distance
     bmesh.ops.dissolve_limit(
         bm,
-        angle_limit=ANGLE,
+        angle_limit=DISSOLVE_ANGLE,
         verts=bm.verts,
         edges=bm.edges,
         delimit={"NORMAL"},
     )
-    bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=0.0001)
+    bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=MERGE_DISTANCE)
 
     # Select and delete interior faces
     interior_faces = _select_interior_faces(bm)
@@ -60,7 +67,7 @@ def _process_mesh_geometry(design_obj):
     # Second dissolve limited and recalculate normals
     bmesh.ops.dissolve_limit(
         bm,
-        angle_limit=ANGLE,
+        angle_limit=DISSOLVE_ANGLE,
         use_dissolve_boundaries=False,
         verts=bm.verts,
         edges=bm.edges,
@@ -228,43 +235,95 @@ def _batch_convert_curves_to_meshes(curve_objects: list) -> list:
     return new_mesh_objects
 
 
-def _select_interior_faces(bm) -> dict:
+def _get_combined_max_dimension(mesh_objects: list) -> float:
+    """Return the largest XY span across all mesh objects.
+
+    Assumes world transforms have already been baked into mesh data
+    (all objects at identity transform).
     """
-    Select interior faces in a BMesh using a two-pass method:
-        1. Identify candidate faces where all edges have more than 2 face users.
-        2. Verify candidates with raycasts to ensure they're truly interior, if the ray
-        hits another face along the normal direction whose normal is roughly opposite.
+    min_x = min_y = float("inf")
+    max_x = max_y = float("-inf")
+    for obj in mesh_objects:
+        for v in obj.data.vertices:
+            min_x = min(min_x, v.co.x)
+            max_x = max(max_x, v.co.x)
+            min_y = min(min_y, v.co.y)
+            max_y = max(max_y, v.co.y)
+    return max(max_x - min_x, max_y - min_y) if mesh_objects else 0.0
+
+
+def _boolean_self_union(obj) -> bool:
+    """Merge overlapping shells inside *obj* into one clean outer shell.
+
+    Uses Blender's Exact boolean solver with ``use_self`` to union all
+    overlapping volumes without needing a second operand object.
+
+    Returns True if the modifier was applied successfully.
+    """
+    mod = obj.modifiers.new("_SelfUnion", "BOOLEAN")
+    mod.operation = "UNION"
+    mod.solver = "EXACT"
+    mod.use_self = True
+
+    try:
+        depsgraph = bpy.context.evaluated_depsgraph_get()
+        obj_eval = obj.evaluated_get(depsgraph)
+        new_mesh = bpy.data.meshes.new_from_object(obj_eval)
+    except Exception:
+        obj.modifiers.remove(mod)
+        return False
+
+    old_mesh = obj.data
+    obj.data = new_mesh
+    bpy.data.meshes.remove(old_mesh)
+    obj.modifiers.clear()
+    return True
+
+
+def _select_interior_faces(bm) -> list:
+    """
+    Select interior faces using BVH-tree raycasting.
+
+    A face is considered interior when:
+        1. All its edges border more than 2 faces (structural candidate).
+        2. A ray cast along its outward normal hits another face whose
+           normal is roughly opposing, confirming the face is sandwiched
+           inside the mesh.
+
+    Uses ``BVHTree`` for O(n log m) performance instead of brute-force
+    O(n × m) centre-to-centre checks.
+
     Args:
         bm: The BMesh to operate on
     Returns:
-        A dictionary with selected interior faces
+        A list of interior faces to delete
     """
     candidate_faces = [
         f for f in bm.faces if f.edges and all(len(e.link_faces) > 2 for e in f.edges)
     ]
+    if not candidate_faces:
+        return []
+
+    bm.faces.ensure_lookup_table()
+    bm.verts.ensure_lookup_table()
+    bvh = BVHTree.FromBMesh(bm, epsilon=0.0)
 
     interior_faces = []
-    bm.faces.ensure_lookup_table()
+    OFFSET = 0.0001  # slight offset to avoid self-intersection
 
     for face in candidate_faces:
-        ray_origin = face.calc_center_median()
-        ray_direction = face.normal
+        origin = face.calc_center_median()
+        normal = face.normal.normalized()
 
-        # Check if ray hits another face
-        hit = False
-        for other_face in bm.faces:
-            if other_face == face:
-                continue
-            # If we can reach the back of another face along the normal, this face is interior
-            result = other_face.calc_center_median() - ray_origin
-            if result.dot(ray_direction) > 0.001:  # Small epsilon for floating point
-                # Check if the other face's normal is roughly opposite
-                if other_face.normal.dot(ray_direction) < -0.5:
-                    hit = True
-                    break
+        # Cast along outward normal from just above the face surface
+        hit_loc, hit_normal, _hit_idx, _hit_dist = bvh.ray_cast(
+            origin + normal * OFFSET, normal,
+        )
 
-        if hit:
-            interior_faces.append(face)
+        if hit_loc is not None and hit_normal is not None:
+            # Hit face has opposing normal → this face is interior
+            if hit_normal.dot(normal) < -0.1:
+                interior_faces.append(face)
 
     return interior_faces
 
@@ -411,23 +470,65 @@ def process_svg_to_mesh(filepath: str, design_num: int, report_func=None) -> boo
         if not mesh_objects:
             return False
 
-        # Join all mesh objects into one using BMesh
-        design_obj = _join_mesh_objects_bmesh(mesh_objects)
+        # Bake world transforms into mesh data so all paths share one
+        # coordinate space before we scale and extrude them.
+        for obj in mesh_objects:
+            obj.data.transform(obj.matrix_world)
+            obj.matrix_world = Matrix.Identity(4)
+
+        # Safety guard: reject excessively complex SVGs
+        total_verts = sum(len(obj.data.vertices) for obj in mesh_objects)
+        if total_verts > MAX_MESH_VERTS:
+            if report_func:
+                report_func(
+                    {"WARNING"},
+                    f"SVG is too complex ({total_verts:,} vertices, max {MAX_MESH_VERTS:,}). "
+                    "Simplify the SVG or use a less detailed design.",
+                )
+            for obj in mesh_objects:
+                bpy.data.objects.remove(obj, do_unlink=True)
+            return False
+
+        # Uniform scale based on combined bounding box
+        max_dim = _get_combined_max_dimension(mesh_objects)
+        if max_dim > 0:
+            scale_factor = MAX_DESIGN_SIZE / max_dim
+            for obj in mesh_objects:
+                obj.scale = (scale_factor, scale_factor, scale_factor)
+                _apply_scale_to_mesh(obj)
+
+        # ---- KEY FIX: process each path independently ----
+        # Extruding each path as its own closed shell prevents
+        # overlapping paths from sharing edges (which would be non-manifold).
+        valid_meshes = []
+        for obj in mesh_objects:
+            if len(obj.data.polygons) == 0:
+                bpy.data.objects.remove(obj, do_unlink=True)
+                continue
+            _process_mesh_geometry(obj)
+            if len(obj.data.polygons) > 0:
+                valid_meshes.append(obj)
+            else:
+                bpy.data.objects.remove(obj, do_unlink=True)
+
+        if not valid_meshes:
+            if report_func:
+                report_func(
+                    {"ERROR"},
+                    "No valid geometry after processing SVG paths.",
+                )
+            return False
+
+        # Join all independently-extruded shells into one object
+        design_obj = _join_mesh_objects_bmesh(valid_meshes)
         if not design_obj:
             return False
 
         design_obj.name = f"Design_{design_num}_SVG"
 
-        # Calculate scale to fit within 40mm
-        dimensions = design_obj.dimensions
-        max_dim = max(dimensions.x, dimensions.y)
-        if max_dim > 0:
-            scale_factor = 40.0 / max_dim
-            design_obj.scale = (scale_factor, scale_factor, scale_factor)
-
-        _apply_scale_to_mesh(design_obj)
-
-        _process_mesh_geometry(design_obj)
+        # Merge overlapping shells into one clean surface so the
+        # boolean-difference in geometry nodes gets a proper input.
+        _boolean_self_union(design_obj)
 
         _set_origin_to_center_of_mass(design_obj)
 
@@ -446,15 +547,21 @@ def process_svg_to_mesh(filepath: str, design_num: int, report_func=None) -> boo
 
         logo_placer_node_group = _find_logo_placer_node_group()
         if not logo_placer_node_group:
+            if report_func:
+                report_func({"ERROR"}, "Logo Placer node group not found. Ensure the scene is set up.")
             return False
 
         design_input_node = _find_design_input_node(logo_placer_node_group, design_num)
         if not design_input_node:
+            if report_func:
+                report_func({"ERROR"}, f"Design {design_num} input node not found in Logo Placer.")
             return False
 
         try:
             design_input_node.inputs[0].default_value = design_obj
-        except Exception:
+        except Exception as e:
+            if report_func:
+                report_func({"ERROR"}, f"Failed to assign design to node: {e}")
             return False
 
         design_obj.hide_viewport = True

--- a/nfcCardGen/ui_panels.py
+++ b/nfcCardGen/ui_panels.py
@@ -123,17 +123,8 @@ class VIEW3D_PT_tag_card_shape(Panel):
             layout.prop(props, "magnet_depth", text="Magnet Hole Depth")
         layout.prop(props, "nfc_choice", text="Add NFC Slot")
 
-        card_height = (
-            props.initial_height
-            + (props.magnet_depth if props.magnet_choice else 0)
-            + (0.8 if props.nfc_choice else 0)
-        )
-        final_height = (
-            props.initial_height
-            + (props.magnet_depth if props.magnet_choice else 0)
-            + (0.8 if props.nfc_choice else 0)
-            + (0.6 if not props.inset_choice else 0)
-        )
+        card_height = props.get_card_height()
+        final_height = props.get_final_height()
 
         row = layout.row()
         row.scale_y = 0.6
@@ -310,6 +301,7 @@ class VIEW3D_PT_tag_svg_to_mesh_design(Panel):
             if props.shape_preset == "RECTANGLE"
             else "Inset Design",
         )
+        layout.prop(props, "design_boolean_solver", text="Boolean Solver")
 
     def _draw_design_section(self, layout, props, design_num: int) -> None:
         box = layout.box()
@@ -354,6 +346,9 @@ class VIEW3D_PT_tag_svg_to_mesh_design(Panel):
         elif qr_type == "WIFI":
             box.prop(props, f"qr_wifi_ssid_{design_num}", text="SSID")
             box.prop(props, f"qr_wifi_password_{design_num}", text="Password")
+            warn_row = box.row()
+            warn_row.scale_y = 0.7
+            warn_row.label(text="Note: password is stored in .blend file", icon="ERROR")
             box.prop(props, f"qr_wifi_security_{design_num}", text="Encryption")
             box.prop(props, f"qr_wifi_hidden_{design_num}", text="Hidden Network")
         elif qr_type == "CONTACT":
@@ -460,7 +455,7 @@ class VIEW3D_PT_tag_design_1_text(Panel):
             font_col.label(text=f"Font: {os.path.basename(props.font_path_1)}", icon="FONT_DATA")
         else:
             font_col.label(text="Font: Default", icon="FONT_DATA")
-        font_col.operator("object.nfc_load_font_design1", text="Load Custom Font", icon="FILEBROWSER")
+        font_col.operator("object.nfc_load_font", text="Load Custom Font", icon="FILEBROWSER").design_num = 1
 
         layout.separator(factor=0.5)
 
@@ -542,7 +537,7 @@ class VIEW3D_PT_tag_design_2_text(Panel):
             font_col.label(text=f"Font: {os.path.basename(props.font_path_2)}", icon="FONT_DATA")
         else:
             font_col.label(text="Font: Default", icon="FONT_DATA")
-        font_col.operator("object.nfc_load_font_design2", text="Load Custom Font", icon="FILEBROWSER")
+        font_col.operator("object.nfc_load_font", text="Load Custom Font", icon="FILEBROWSER").design_num = 2
 
         layout.separator(factor=0.5)
 
@@ -617,12 +612,7 @@ class VIEW3D_PT_tag_card_export(Panel):
 
     def _get_card_info_lines(self, props) -> list:
         """Return a list of card info lines to display."""
-        final_height = (
-            props.initial_height
-            + (props.magnet_depth if props.magnet_choice else 0)
-            + (0.8 if props.nfc_choice else 0)
-            + (0 if props.inset_choice else 0.6)
-        )
+        final_height = props.get_final_height()
         info_lines = [f"Final Height: {final_height:.2f} mm"]
         if props.magnet_choice:
             info_lines.append(f"Magnet Depth: {props.magnet_depth:.2f} mm")
@@ -681,8 +671,10 @@ def _camera_view_box(layout, panel_area) -> None:
         side_op = row.operator("object.nfc_set_view", text="Side", icon="AXIS_SIDE")
         side_op.view_type = "SIDE"
     else:
-        print(f"Error: Unknown panel area '{panel_area}' for camera view box.")
-        pass
+        raise ValueError(
+            f"Unknown panel area '{panel_area}' for camera view box. "
+            f"Expected one of: CARD_SHAPE, MAGNET_CAVITY, DESIGN_IMPORT"
+        )
 
 
 def register() -> None:

--- a/nfcCardGen/utils.py
+++ b/nfcCardGen/utils.py
@@ -223,6 +223,59 @@ def setup_driver_connection(
         return False
 
 
+def update_design_boolean_solver(solver_value, report_func=None):
+    """Set the boolean solver on all Mesh Boolean nodes inside the Logo Placer node group.
+
+    Args:
+        solver_value (str): 'MANIFOLD' or 'EXACT'
+        report_func (callable, optional): Blender operator report function for error messages
+
+    Returns:
+        bool: True if at least one node was updated, False otherwise
+    """
+    # Find the Logo Placer node group (flexible match)
+    logo_ng = None
+    for ng_name in bpy.data.node_groups.keys():
+        if "logo" in ng_name.lower() and "placer" in ng_name.lower():
+            logo_ng = bpy.data.node_groups[ng_name]
+            break
+    if logo_ng is None:
+        logo_ng = bpy.data.node_groups.get("Logo Placer")
+    if logo_ng is None:
+        if report_func:
+            report_func({"ERROR"}, "Logo Placer node group not found")
+        return False
+
+    updated = False
+    for node in logo_ng.nodes:
+        if node.type == 'MESH_BOOLEAN' and hasattr(node, 'solver'):
+            node.solver = solver_value
+            updated = True
+    return updated
+
+
+def get_design_boolean_solver():
+    """Read the current boolean solver from the Logo Placer node group.
+
+    Returns:
+        str: 'MANIFOLD' or 'EXACT', or None if not found
+    """
+    logo_ng = None
+    for ng_name in bpy.data.node_groups.keys():
+        if "logo" in ng_name.lower() and "placer" in ng_name.lower():
+            logo_ng = bpy.data.node_groups[ng_name]
+            break
+    if logo_ng is None:
+        logo_ng = bpy.data.node_groups.get("Logo Placer")
+    if logo_ng is None:
+        return None
+
+    for node in logo_ng.nodes:
+        if node.type == 'MESH_BOOLEAN' and hasattr(node, 'solver'):
+            return node.solver
+    return None
+
+
 def update_modifier_input(modifier_name, socket_name, value, report_func=None):
     """Update a specific input on a geometry nodes modifier.
 


### PR DESCRIPTION
Bump to v1.2.0 and large refactor: update changelog and manifest, add UI and sync robustness, and rewrite QR generation pipeline.

Highlights:
- Release/version metadata: bumped blender_manifest to 1.2.0 and updated CHANGELOG with user-facing notes.
- Operator fixes: modifier->property sync rewritten with dictionary-based enum conversion and property-name overrides; failed syncs now collect and report a warning. Design boolean solver is now synced from node utils into scene props.
- Toggle operator simplified to rely on property updates (avoids manual modifier toggling) and QR-mode toggles now properly clear has_design flags when switching modes.
- Font loading: consolidated two design-specific font loaders into a single operator with a design_num parameter to target either design slot.
- Properties refactor: replaced many repetitive update callbacks with a single factory (_make_updater); added design_boolean_solver EnumProperty and update callback; added helper methods to compute card heights.
- QR generation rewrite: removed SVG/temp-file intermediary and implemented direct, manifold BMesh construction for QR modules (supports multiple module styles, rounded/squircle handling, and extrusion), improving speed and robustness; QR building now connects generated mesh into the Logo Placer design input node and hides the mesh in the viewport.
- Performance/robustness fixes noted in changelog: SVG import path extrusion per-path, boolean self-union for imported SVG meshes, QR Z-origin centering, and ROUNDED module rendering improvements.

Other: trimmed long manifest description text and various small cleanups across svg_import, utils, operators and properties to support the above changes.